### PR TITLE
added a bot to check images for cancerous moles

### DIFF
--- a/scripts/mole_check.coffee
+++ b/scripts/mole_check.coffee
@@ -1,0 +1,28 @@
+module.exports = (robot) ->
+
+  robot.hear /((http|https).*)/i, (msg) ->
+
+    image_url = escape(msg.match[1])
+    server_url = "http://50a70d87.ngrok.io:9000/api/hubot?url=" + image_url
+
+    robot.http(server_url).get() (err, res, body) ->
+
+      if err
+        msg.send "Encountered an error :( #{err}"
+
+      switch res.statusCode
+        when 200
+          response = switch body
+            when "atypical"
+              "This could potentially be dangerous. Please consult a doctor."
+            when "common"
+              "Everything is fine. There is nothing to worry about."
+            when "melanoma"
+              "This looks nasty. Please see a doctor."
+            else
+              ""
+
+          msg.send(response)
+        when 400
+          msg.send("Ups. Something went wront with the mole server")
+


### PR DESCRIPTION
I added a hubot integration for our mole detection server.  It is designed to work with Slack image uploads.
#### How does it work?
1. Upload a new image in a Slack channel.
2. The bot listens for all strings containing `http` and will pick up the image url.
3. The bot will forward Slack's image url to our server, which downloads the image in question.
4. We do a mole classification for the image.

Currently the mole recognition server is limited to only accepting links hosted on Slack's server.
#### Demo

![animations4](https://cloud.githubusercontent.com/assets/1105056/15990473/739d74a6-3093-11e6-819e-77eada0aec17.gif)
